### PR TITLE
Fix error class naming

### DIFF
--- a/lib/tinplate/errors.rb
+++ b/lib/tinplate/errors.rb
@@ -14,7 +14,7 @@ module Tinplate
     end
   end
 
-  class ServiceUnvailableError < Error; end
+  class ServiceUnavailableError < Error; end
   class NoSignatureError < Error; end
   class NoCreditsRemainingError < Error; end
 end

--- a/lib/tinplate/errors.rb
+++ b/lib/tinplate/errors.rb
@@ -2,10 +2,10 @@ module Tinplate
   class Error < StandardError
     def self.from_response(code, type, message)
       klass = case message
-              when /503 Service Unavailable/          then Tinplate::ServiceUnavailable
-              when /service is busy due to high load/ then Tinplate::ServiceUnavailable
+              when /503 Service Unavailable/          then Tinplate::ServiceUnavailableError
+              when /service is busy due to high load/ then Tinplate::ServiceUnavailableError
               when /Image too simple/                 then Tinplate::NoSignatureError
-              when /purchase another bundle/          then Tinplate::NoCreditsRemaining
+              when /purchase another bundle/          then Tinplate::NoCreditsRemainingError
               else
                 Tinplate::Error
               end
@@ -14,7 +14,7 @@ module Tinplate
     end
   end
 
-  class ServiceUnvailable < Error; end
+  class ServiceUnvailableError < Error; end
   class NoSignatureError < Error; end
-  class NoCreditsRemaining < Error; end
+  class NoCreditsRemainingError < Error; end
 end


### PR DESCRIPTION
Two of the error classes were missing `Error` in their name 👎 
