### PR TITLE
API v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ There are only three API actions available: `search`, `remaining_searches` (to c
 tineye = Tinplate::TinEye.new
 results = tineye.search(image_url: "http://example.com/photo.jpg")
 
-results.total_results    # => 2
-results.total_backlinks  # => 3
-results.matches          # => an Array of matched images (see below)
+results.stats.total_results    # => 2
+results.stats.total_backlinks  # => 3
+results.matches                # => an Array of matched images (see below)
 
 results.matches.each do |match|
   # Do what you like with this matched image. The world is your oyster.
@@ -77,9 +77,14 @@ results = tineye.search(image_path: "/home/alice/example.jpg")
 An `OpenStruct` object with the following attributes (/w example values):
 
 ```ruby
+domain: "ucsb.edu",
+top_level_domain: "ucsb.edu",
 width: 400
 height: 300
-size: 50734
+size: 50734,
+filesize: 195840,
+score: 88.9,
+tags: ["collection"],
 image_url: "http://images.tineye.com/result/0f1e84b7b7538e8e7de048f4d45eb8f579e3e999941b3341ed9a754eb447ebb1",
 format: "JPEG",
 contributor: true,

--- a/lib/tinplate/request_authenticator.rb
+++ b/lib/tinplate/request_authenticator.rb
@@ -45,7 +45,7 @@ module Tinplate
     end
 
     def signature
-      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"),
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"),
                               Tinplate.configuration.private_key,
                               signature_components.join)
     end

--- a/lib/tinplate/search_results.rb
+++ b/lib/tinplate/search_results.rb
@@ -1,9 +1,8 @@
 module Tinplate
   class SearchResults < OpenStruct
     def initialize(data)
-      super total_backlinks: data["total_backlinks"],
-            total_results:   data["total_results"],
-            matches:         parsed_matches(data["matches"])
+      super stats:   OpenStruct.new(data["stats"]),
+            matches: parsed_matches(data["results"]["matches"])
     end
 
     private

--- a/lib/tinplate/tineye.rb
+++ b/lib/tinplate/tineye.rb
@@ -23,9 +23,14 @@ module Tinplate
 
     def remaining_searches
       results = request("remaining_searches")["results"]
-      OpenStruct.new(remaining_searches: results["remaining_searches"],
-                     start_date:  DateTime.parse(results["start_date"]),
-                     expire_date: DateTime.parse(results["expire_date"]))
+
+      bundles = results["bundles"].map do |bundle|
+        OpenStruct.new(remaining_searches: bundle["remaining_searches"],
+                       start_date:  DateTime.parse(bundle["start_date"]),
+                       expire_date: DateTime.parse(bundle["expire_date"]))
+      end
+
+      OpenStruct.new(total_remaining_searches: results["total_remaining_searches"], bundles: bundles)
     end
 
     def image_count

--- a/lib/tinplate/tineye.rb
+++ b/lib/tinplate/tineye.rb
@@ -18,7 +18,7 @@ module Tinplate
 
       response = request("search", options.merge(img))
 
-      Tinplate::SearchResults.new(response["results"])
+      Tinplate::SearchResults.new(response)
     end
 
     def remaining_searches

--- a/spec/request_authenticator_spec.rb
+++ b/spec/request_authenticator_spec.rb
@@ -5,7 +5,7 @@ describe Tinplate::RequestAuthenticator do
   let(:nonce) { "ABCD1234" }
 
   context "without image_name (i.e. GET request)" do
-    let(:sig)   { "e4ed817c186b0ca701b73bcd051081a8e44d0cfc" }
+    let(:sig)   { "3fff4830af34042a3e98a9d45e45e80694f864a6ee4abef7934a3f2c4d20d287" }
 
     let(:authenticator) do
       auth = Tinplate::RequestAuthenticator.new("image_count", { offset: 1, limit: 2 })
@@ -49,7 +49,7 @@ describe Tinplate::RequestAuthenticator do
   end
 
   context "with image_name (i.e. POST request)" do
-    let(:sig)   { "0a4ba8627ca3fb22a1fd2d535b69e2fb56475bd4" }
+    let(:sig)   { "780bf5b105520ad7bd79aae72994e8d03828dead813a49d2f70f83a461221bd0" }
 
     let(:authenticator) do
       auth = Tinplate::RequestAuthenticator.new("search", { offset: 1, limit: 2 }, "Pretty Image.jpg")

--- a/spec/tineye_spec.rb
+++ b/spec/tineye_spec.rb
@@ -31,57 +31,90 @@ describe Tinplate::TinEye do
 
   describe "#search" do
     let(:valid_response) do
-      {
-        stats: {
-          timestamp:  "1259096177.74",
-          query_time: "2.46"
-        },
-        code:     200,
-        messages: [],
-        results: {
-          total_backlinks: 3,
-          total_results: 2,
-          matches: [
-            {
-              width: 400,
-              image_url: "http://images.tineye.com/result/0f1e84b7b7538e8e7de048f4d45eb8f579e3e999941b3341ed9a754eb447ebb1",
-              backlinks: [
-                {
-                  url: "http://weblogs.newsday.com/features/home/cheap_thrills_blog/stripey-yarnDIY-thumb.jpeg",
-                  crawl_date: "2012-06-30",
-                  backlink: "http://weblogs.newsday.com/features/home/cheap_thrills_blog/2007/05/"
-                }
-              ],
-              format: "JPEG",
-              overlay: "overlay/507bb6bf9a397284e2330be7c0671aadc7319b4b/0f1e84b7b7538e8e7de048f4d45eb8f579e3e999941b3341ed9a754eb447ebb1?m21=-9.06952e-05&m22=0.999975&m23=0.0295591&m11=0.999975&m13=-0.0171177&m12=9.06952e-05",
-              contributor: true,
-              size: 50734,
-              height: 300
-            },
-            {
-              width: 180,
-              image_url: "http://images.tineye.com/result/0dd198eed842082619fe783e73bfd2c9291522d973ad64b871e605530b817800",
-              backlinks: [
-                {
-                  url: "http://photos3.meetupstatic.com/photos/event/a/7/2/5/global_5622789.jpeg",
-                  crawl_date: "2012-06-30",
-                  backlink: "http://www.meetup.com/geneva-meetup/calendar/11331213/"
-                },
-                {
-                  url: "http://photos3.meetupstatic.com/photos/event/a/7/2/5/global_5622789.jpeg",
-                  crawl_date: "2012-06-29",
-                  backlink: "http://www.meetup.com/geneva-meetup/calendar/11316812/"
-                }
-              ],
-              format: "JPEG",
-              overlay: "overlay/507bb6bf9a397284e2330be7c0671aadc7319b4b/0dd198eed842082619fe783e73bfd2c9291522d973ad64b871e605530b817800?m21=0.00156478&m22=2.21849&m23=-0.0262089&m11=2.21849&m13=0.254416&m12=-0.00156478",
-              contributor: false,
-              size: 10010,
-              height: 135
-            }
-          ]
+      <<-JSON
+        {
+          "stats": {
+            "timestamp": "1488909217.20",
+            "query_time": "4.74",
+            "total_backlinks": 26135,
+            "total_collection": 57,
+            "total_results": 6683,
+            "total_stock": 4,
+            "total_filtered_results": 6683
+          },
+          "code": 200,
+          "messages": [],
+          "results": {
+            "matches": [
+              {
+                "domain": "designerstalk.com",
+                "backlinks": [
+                  {
+                    "url": "http://www.cybersalt.org/images/funnypictures/cats/catmelonhead.jpg",
+                    "crawl_date": "2015-03-18",
+                    "backlink": "http://www.designerstalk.com/forums/tv-film/67944-dredd-2012-a-post904441.html"
+                  },
+                  {
+                    "url": "http://www.cybersalt.org/images/funnypictures/cats/catmelonhead.jpg",
+                    "crawl_date": "2015-07-09",
+                    "backlink": "http://www.designerstalk.com/forums/tv-film/67944-dredd-2012-a-post888204.html"
+                  },
+                  {
+                    "url": "http://www.cybersalt.org/images/funnypictures/cats/catmelonhead.jpg",
+                    "crawl_date": "2015-03-20",
+                    "backlink": "http://www.designerstalk.com/forums/tv-film/67944-dredd-2012-a-post887253.html"
+                  },
+                  {
+                    "url": "http://www.cybersalt.org/images/funnypictures/cats/catmelonhead.jpg",
+                    "crawl_date": "2015-03-11",
+                    "backlink": "http://www.designerstalk.com/forums/tv-film/67944-dredd-2012-a-last-post.html"
+                  },
+                  {
+                    "url": "http://www.cybersalt.org/images/funnypictures/cats/catmelonhead.jpg",
+                    "crawl_date": "2015-03-11",
+                    "backlink": "http://www.designerstalk.com/forums/tv-film/67944-dredd-2012-a.html"
+                  }
+                ],
+                "format": "JPEG",
+                "filesize": 239481,
+                "overlay": "overlay/dca08fc6b2ec4b9e04f94a4e29223f6af3dd6555/ba97680a685da25e5910b8cb95d6e9680be1fab360a0daad8a8a537ab992948f?m21=-4.63347e-05&m22=0.999952&m23=0.00784483&m11=0.999952&m13=0.00137017&m12=4.63347e-05",
+                "height": 451,
+                "width": 531,
+                "image_url": "http://img.tineye.com/result/ba97680a685da25e5910b8cb95d6e9680be1fab360a0daad8a8a537ab992948f",
+                "query_hash": "dca08fc6b2ec4b9e04f94a4e29223f6af3dd6555",
+                "top_level_domain": "designerstalk.com",
+                "tags": [],
+                "size": 239481
+              },
+              {
+                "domain": "reddit.com",
+                "backlinks": [
+                  {
+                    "url": "http://www.cybersalt.org/images/funnypictures/cats/catmelonhead.jpg",
+                    "crawl_date": "2016-07-16",
+                    "backlink": "https://www.reddit.com/r/OldAsTheNet/"
+                  },
+                  {
+                    "url": "https://i.imgur.com/s69Vo.jpg",
+                    "crawl_date": "2016-03-24",
+                    "backlink": "https://www.reddit.com/r/RoastMe/comments/3j7e80/i_fuel_myself_on_the_roasts_of_the_many/"
+                  }
+                ],
+                "format": "JPEG",
+                "filesize": 239481,
+                "overlay": "overlay/dca08fc6b2ec4b9e04f94a4e29223f6af3dd6555/ba97680a685da25e5910b8cb95d6e9680be1fab360a0daad8a8a537ab992948f?m21=-4.63347e-05&m22=0.999952&m23=0.00784483&m11=0.999952&m13=0.00137017&m12=4.63347e-05",
+                "height": 451,
+                "width": 531,
+                "image_url": "http://img.tineye.com/result/ba97680a685da25e5910b8cb95d6e9680be1fab360a0daad8a8a537ab992948f",
+                "query_hash": "dca08fc6b2ec4b9e04f94a4e29223f6af3dd6555",
+                "top_level_domain": "reddit.com",
+                "tags": [],
+                "size": 239481
+              }
+            ]
+          }
         }
-      }.to_json
+      JSON
     end
 
     it "parses results from URL search" do
@@ -89,10 +122,19 @@ describe Tinplate::TinEye do
       allow(tineye).to receive(:connection).and_return(connection)
 
       results = tineye.search(image_url: "http://example.com/photo.jpg")
-      expect(results.total_results).to eq 2
-      expect(results.total_backlinks).to eq 3
-      expect(results.matches.count). to eq 2
+      stats = {
+        timestamp:              "1488909217.20",
+        query_time:             "4.74",
+        total_backlinks:        26135,
+        total_collection:       57,
+        total_results:          6683,
+        total_stock:            4,
+        total_filtered_results: 6683
+      }
 
+      expect(results.stats.to_h).to eq stats
+      expect(results.matches.count). to eq 2
+      expect(results.matches.first.tags).to be_an Array
       expect(results.matches.first.backlinks.first).to be_a OpenStruct
     end
 
@@ -107,9 +149,9 @@ describe Tinplate::TinEye do
 
       results = tineye.search(image_path: path)
 
-      expect(results.total_results).to eq 2
-      expect(results.total_backlinks).to eq 3
-      expect(results.matches.count). to eq 2
+      expect(results.stats.total_results).to eq 6683
+      expect(results.stats.total_backlinks).to eq 26135
+      expect(results.matches.count).to eq 2
 
       expect(results.matches.first.backlinks.first).to be_a OpenStruct
     end

--- a/spec/tineye_spec.rb
+++ b/spec/tineye_spec.rb
@@ -195,19 +195,36 @@ describe Tinplate::TinEye do
 
   describe "#remaining_searches" do
     let(:valid_response) do
-      {
-        stats: {
-          timestamp: "1250535183.20",
-          query_time: "0.01"
-        },
-        code:     200,
-        messages: [],
-        results: {
-          remaining_searches: 24998,
-          start_date:  "2009-09-18 16:01:49 UTC",
-          expire_date: "2009-11-02 16:01:49 UTC"
+      <<-JSON
+        {
+          "stats": {
+            "timestamp": "1490029267.12",
+            "query_time": "0.07"
+          },
+          "code": 200,
+          "messages": [],
+          "results": {
+            "bundles": [
+              {
+                "remaining_searches": 719,
+                "start_date": "2016-12-17 03:42:50 UTC",
+                "expire_date": "2018-12-17 03:42:50 UTC"
+              },
+              {
+                "remaining_searches": 10000,
+                "start_date": "2017-02-25 16:31:09 UTC",
+                "expire_date": "2019-02-25 16:31:09 UTC"
+              },
+              {
+                "remaining_searches": 10000,
+                "start_date": "2017-03-19 09:50:16 UTC",
+                "expire_date": "2019-03-19 09:50:16 UTC"
+              }
+            ],
+            "total_remaining_searches": 20719
+          }
         }
-      }.to_json
+      JSON
     end
 
     it "returns parsed object" do
@@ -215,9 +232,10 @@ describe Tinplate::TinEye do
       allow(tineye).to receive(:connection).and_return(connection)
 
       remaining = tineye.remaining_searches
-      expect(remaining.remaining_searches).to eq 24998
-      expect(remaining.start_date).to  eq DateTime.parse("2009-09-18 16:01:49 UTC")
-      expect(remaining.expire_date).to eq DateTime.parse("2009-11-02 16:01:49 UTC")
+      expect(remaining.bundles.first.remaining_searches).to eq 719
+      expect(remaining.bundles.first.start_date).to  eq DateTime.parse("2016-12-17 03:42:50 UTC")
+      expect(remaining.bundles.first.expire_date).to eq DateTime.parse("2018-12-17 03:42:50 UTC")
+      expect(remaining.total_remaining_searches).to eq 20719
     end
 
     it "raises on non-200 response" do


### PR DESCRIPTION
Closes #8.

Not much to see here - response JSON has slightly changed, so handle that parsing here. TinEye supplies sample responses for everything, so it's easy to just run specs against those.