### PR TITLE
Relax faraday version requirement

### DIFF
--- a/tinplate.gemspec
+++ b/tinplate.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", [">= 0.9.2", "< 1.0.0"]
+  spec.add_dependency "faraday", [">= 0.9.2", "< 2.0.0"]
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake",    "~> 10.0"


### PR DESCRIPTION
Faraday is past version 1.0 now, but the requirement in the gemspec does not allow faraday to be updated (or a number of gems that rely on faraday).