### PR TITLE
Fix error handling and handle more error types

### DIFF
--- a/lib/tinplate/errors.rb
+++ b/lib/tinplate/errors.rb
@@ -1,20 +1,34 @@
 module Tinplate
   class Error < StandardError
-    def self.from_response(code, type, message)
-      klass = case message
-              when /503 Service Unavailable/          then Tinplate::ServiceUnavailableError
-              when /service is busy due to high load/ then Tinplate::ServiceUnavailableError
-              when /Image too simple/                 then Tinplate::NoSignatureError
-              when /purchase another bundle/          then Tinplate::NoCreditsRemainingError
-              else
-                Tinplate::Error
-              end
+    def self.from_response(code, messages)
+      return UnauthorizedError.new(messages.first) if code == 403
 
-      klass.new(message)
+      messages.each do |message|
+        klass = class_from_message(message)
+        return klass.new(messages.join("\n")) if klass
+      end
+
+      Tinplate::Error.new(messages.join("\n"))
+    end
+
+    def self.class_from_message(message)
+      case message
+        when /503 Service Unavailable/          then Tinplate::ServiceUnavailableError
+        when /service is busy due to high load/ then Tinplate::ServiceUnavailableError
+        when /Image too simple/                 then Tinplate::NoSignatureError
+        when /purchase another bundle/          then Tinplate::NoCreditsRemainingError
+        when /Could not download/               then Tinplate::InaccessibleURLError
+        when /Please supply an image/           then Tinplate::InvalidSearchError
+        when /Error reading image data/         then Tinplate::InvalidImageDataError
+      end
     end
   end
 
   class ServiceUnavailableError < Error; end
   class NoSignatureError < Error; end
   class NoCreditsRemainingError < Error; end
+  class UnauthorizedError < Error; end
+  class InaccessibleURLError < Error; end
+  class InvalidSearchError < Error; end
+  class InvalidImageDataError < Error; end
 end

--- a/lib/tinplate/tineye.rb
+++ b/lib/tinplate/tineye.rb
@@ -55,7 +55,7 @@ module Tinplate
       response = ::JSON.parse(response.body)
 
       if response["code"] != 200
-        raise Tinplate::Error.from_response(response["code"], response["messages"][0], response["messages"][1])
+        raise Tinplate::Error.from_response(response["code"], response["messages"])
       end
 
       response

--- a/spec/tineye_spec.rb
+++ b/spec/tineye_spec.rb
@@ -12,7 +12,7 @@ describe Tinplate::TinEye do
         query_time: "0.51"
       },
       code:     400,
-      messages: ["API_ERROR", "Couldn't download URL, caught exception: HTTPError()"],
+      messages: ["API_ERROR", "Generic Error"],
       results:  []
     }.to_json
   end
@@ -24,7 +24,7 @@ describe Tinplate::TinEye do
         query_time: "0.51"
       },
       code:     500,
-      messages: ["NO_SIGNATURE_ERROR", "Image too simple or too small to create unique signature."],
+      messages: ["Image too simple or too small to create unique signature."],
       results:  []
     }.to_json
   end


### PR DESCRIPTION
The TinEye API doesn't seem to return error types anymore, which was causing all errors to be treated as `Tinplate::Error` instead of the more specific types.

This changes how the messages are processed and adds a few more error types based on the documentation at https://help.tineye.com/article/181-list-of-tineye-api-error-messages

Fixes #18.