### PR TITLE
Add specific error for too many concurrent requests

### DIFF
--- a/lib/tinplate/errors.rb
+++ b/lib/tinplate/errors.rb
@@ -20,6 +20,7 @@ module Tinplate
         when /Could not download/               then Tinplate::InaccessibleURLError
         when /Please supply an image/           then Tinplate::InvalidSearchError
         when /Error reading image data/         then Tinplate::InvalidImageDataError
+        when /Too many concurrent requests/     then Tinplate::TooManyRequestsError
       end
     end
   end
@@ -31,4 +32,5 @@ module Tinplate
   class InaccessibleURLError < Error; end
   class InvalidSearchError < Error; end
   class InvalidImageDataError < Error; end
+  class TooManyRequestsError < Error; end
 end

--- a/spec/tineye_spec.rb
+++ b/spec/tineye_spec.rb
@@ -29,6 +29,15 @@ describe Tinplate::TinEye do
     }.to_json
   end
 
+  let(:too_many_requests_error_response) do
+    {
+      stats:    "",
+      code:     429,
+      messages: ["Too many concurrent requests", "Max concurrent requests is 4"],
+      results:  []
+    }.to_json
+  end
+
   describe "#search" do
     let(:valid_response) do
       <<-JSON
@@ -163,6 +172,14 @@ describe Tinplate::TinEye do
         expect {
           tineye.search(image_url: "http://example.com/photo.jpg")
         }.to raise_error(Tinplate::Error)
+      end
+
+      it "raises a TooManyRequestsError" do
+        connection = double(get: double(body: too_many_requests_error_response))
+        allow(tineye).to receive(:connection).and_return(connection)
+        expect {
+          tineye.search(image_url: "http://example.com/photo.jpg")
+        }.to raise_error(Tinplate::TooManyRequestsError)
       end
 
       it "raises a NoSignatureError" do


### PR DESCRIPTION
Isolating this error so its easier to capture to set up appropriate throttling and concurrency rules